### PR TITLE
fix: ticket reachability graying, settings debounce, waiting banner, UI fixes

### DIFF
--- a/app/src/main/java/at/aau/serg/scotlandyard/dtos/GameStateDto.kt
+++ b/app/src/main/java/at/aau/serg/scotlandyard/dtos/GameStateDto.kt
@@ -11,7 +11,8 @@ data class GameStateDto(
     val playerTickets: Map<String, Map<String, Int>> = emptyMap(),
     val mrXSpecialTickets: Map<String, Int> = emptyMap(),
     val mrXMoveHistory: List<String> = emptyList(),
-    val mrXRevealedPositions: Map<Int, Int> = emptyMap()
+    val mrXRevealedPositions: Map<Int, Int> = emptyMap(),
+    val allPlayersReady: Boolean = false
 ) {
     val isMrXPhase: Boolean get() = currentPhase == "MRX"
     val isDetectivesPhase: Boolean get() = currentPhase == "DETECTIVES"

--- a/app/src/main/java/at/aau/serg/scotlandyard/ui/activity/AssignStartPositionScreen.kt
+++ b/app/src/main/java/at/aau/serg/scotlandyard/ui/activity/AssignStartPositionScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+// import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -343,6 +343,7 @@ private fun WaitingServerState() {
 }
 
 @Composable
+@Suppress("UNUSED_PARAMETER")
 private fun WaitingToSpinState(
     onSimulateShake: () -> Unit,
     onSimulateCheat: () -> Unit = {}
@@ -379,13 +380,13 @@ private fun WaitingToSpinState(
                 }
             }
             // Bottom-right: barely visible cheat
-            Box(
-                modifier = Modifier.align(Alignment.BottomEnd).padding(bottom = 8.dp).alpha(0.13f)
-            ) {
-                TextButton(onClick = onSimulateCheat) {
-                    Text(stringResource(R.string.button_cheat), fontSize = 11.sp, color = DetectiveBlue)
-                }
-            }
+//            Box(
+//                modifier = Modifier.align(Alignment.BottomEnd).padding(bottom = 8.dp).alpha(0.13f)
+//            ) {
+//                TextButton(onClick = onSimulateCheat) {
+//                    Text(stringResource(R.string.button_cheat), fontSize = 11.sp, color = DetectiveBlue)
+//                }
+//            }
         }
     } else {
         Box(
@@ -433,16 +434,16 @@ private fun WaitingToSpinState(
                 }
             }
             // Bottom-right: barely visible cheat
-            Box(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(end = 12.dp, bottom = 12.dp)
-                    .alpha(0.13f)
-            ) {
-                TextButton(onClick = onSimulateCheat) {
-                    Text(stringResource(R.string.button_cheat), fontSize = 12.sp, color = DetectiveBlue)
-                }
-            }
+//            Box(
+//                modifier = Modifier
+//                    .align(Alignment.BottomEnd)
+//                    .padding(end = 12.dp, bottom = 12.dp)
+//                    .alpha(0.13f)
+//            ) {
+//                TextButton(onClick = onSimulateCheat) {
+//                    Text(stringResource(R.string.button_cheat), fontSize = 12.sp, color = DetectiveBlue)
+//                }
+//            }
         }
     }
 }

--- a/app/src/main/java/at/aau/serg/scotlandyard/ui/activity/GameBoardScreen.kt
+++ b/app/src/main/java/at/aau/serg/scotlandyard/ui/activity/GameBoardScreen.kt
@@ -50,9 +50,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -111,6 +113,8 @@ fun GameBoardScreen(
     revealHistoryIndices: Map<Int, Int> = emptyMap(),
     selectedTicket: TicketType? = null,
     currentPlayerColor: Color? = null,
+    ticketReachable: Map<TicketType, Boolean> = emptyMap(),
+    allPlayersReady: Boolean = true,
     onNodeClick: ((Int) -> Unit)? = null,
     onTicketSelect: (TicketType) -> Unit = {},
     onNavigateToSettings: () -> Unit = {}
@@ -150,6 +154,7 @@ fun GameBoardScreen(
                 selectedTicket = selectedTicket,
                 isMyTurn = isMyTurn,
                 currentPlayerColor = currentPlayerColor,
+                ticketReachable = ticketReachable,
                 onNavigateToSettings = onNavigateToSettings,
                 onMrXHistoryClick = { isHistoryOpen = true },
                 onTicketSelect = { type -> onTicketSelect(type) }
@@ -177,10 +182,31 @@ fun GameBoardScreen(
                     onNodeClick = if (isMyTurn) onNodeClick else null
                 )
 
-                // Reveal Mr. X position banner, top-center, auto-dismisses after 5s
+                // Waiting for all players to confirm start positions
+                if (!allPlayersReady) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .padding(top = 8.dp)
+                            .background(Color(0xCC0D1E2E), RoundedCornerShape(8.dp))
+                            .border(2.dp, Color(0xFF888888), RoundedCornerShape(8.dp))
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.banner_waiting_for_players),
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFFCCCCCC),
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+
+                // Reveal Mr. X position banner, top-center, auto-dismisses after 5s or on tap
                 RevealBanner(
                     visible = showRevealBanner,
                     position = revealedPosition ?: 0,
+                    onDismiss = { showRevealBanner = false },
                     modifier = Modifier
                         .align(Alignment.TopCenter)
                         .padding(top = 12.dp)
@@ -397,7 +423,7 @@ private fun MrXHistoryTicketChip(
         else -> Pair(Color.Gray, ticket)
     }
 
-    Box(modifier = modifier) {
+    Box(modifier = modifier.padding(top = 8.dp)) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -438,7 +464,12 @@ private fun MrXHistoryTicketChip(
 }
 
 @Composable
-private fun RevealBanner(visible: Boolean, position: Int, modifier: Modifier = Modifier) {
+private fun RevealBanner(
+    visible: Boolean,
+    position: Int,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     AnimatedVisibility(
         visible = visible,
         modifier = modifier,
@@ -449,6 +480,7 @@ private fun RevealBanner(visible: Boolean, position: Int, modifier: Modifier = M
             modifier = Modifier
                 .background(Color(0xCC0D1E2E), RoundedCornerShape(12.dp))
                 .border(2.dp, AccentGlow, RoundedCornerShape(12.dp))
+                .clickable(onClick = onDismiss)
                 .padding(horizontal = 24.dp, vertical = 10.dp),
             contentAlignment = Alignment.Center
         ) {
@@ -472,6 +504,7 @@ private fun SidePanel(
     selectedTicket: TicketType?,
     isMyTurn: Boolean = false,
     currentPlayerColor: Color? = null,
+    ticketReachable: Map<TicketType, Boolean> = emptyMap(),
     onNavigateToSettings: () -> Unit,
     onMrXHistoryClick: () -> Unit = {},
     onTicketSelect: (TicketType) -> Unit
@@ -533,11 +566,12 @@ private fun SidePanel(
         ) {
             visibleTickets.forEach { type ->
                 val count = ticketCounts[type] ?: 0
+                val canReach = ticketReachable[type] ?: true
                 SidePanelTicketButton(
                     type = type,
                     count = count,
                     isSelected = selectedTicket == type,
-                    isDisabled = count == 0 || !isMyTurn,
+                    isDisabled = count == 0 || !isMyTurn || !canReach,
                     onClick = { onTicketSelect(type) }
                 )
             }
@@ -580,8 +614,17 @@ private fun SidePanel(
 
 @Composable
 private fun MenuButton(onClick: () -> Unit) {
+    val isEnabled = remember { mutableStateOf(true) }
+    val scope = rememberCoroutineScope()
     IconButton(
-        onClick = onClick,
+        onClick = {
+            if (isEnabled.value) {
+                isEnabled.value = false
+                onClick()
+                scope.launch { delay(1_000.milliseconds); isEnabled.value = true }
+            }
+        },
+        enabled = isEnabled.value,
         modifier = Modifier.size(36.dp)
     ) {
         Icon(

--- a/app/src/main/java/at/aau/serg/scotlandyard/ui/activity/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/scotlandyard/ui/activity/MainActivity.kt
@@ -380,8 +380,9 @@ private fun GameBoardRoute(
     // Stored in ViewModel so settings navigation doesn't reset it.
     // MrX never needs this — the phase flip to DETECTIVES already disables their tickets.
     val lastDetectiveMoveRound by gameViewModel.lastDetectiveMoveRound.collectAsState()
+    val allPlayersReady = gameState?.allPlayersReady ?: false
     val movedThisTurn = !isMrX && lastDetectiveMoveRound == (gameState?.currentRound ?: -2)
-    val effectiveIsMyTurn = isMyTurn && !movedThisTurn
+    val effectiveIsMyTurn = isMyTurn && !movedThisTurn && allPlayersReady
 
     val detectiveIdOrder = gameState?.detectivePositions?.keys?.sorted() ?: emptyList()
     val playerPositions  = gameViewModel.buildPlayerPositions(isMrX, detectiveIdOrder)
@@ -403,6 +404,19 @@ private fun GameBoardRoute(
     }
 
     val ticketCounts   = remember(gameState) { gameViewModel.getTicketCounts(playerId, isMrX) }
+
+    // For detectives: gray out tickets that have no reachable destinations from their current position.
+    // Mr. X has unlimited tickets and always has connections, so we skip this for him.
+    val ticketReachable = remember(myPosition) {
+        if (myPosition == null) emptyMap()
+        else mapOf(
+            TicketType.WALKING    to gameViewModel.reachableStations(TicketType.WALKING).isNotEmpty(),
+            TicketType.ESCOOTER   to gameViewModel.reachableStations(TicketType.ESCOOTER).isNotEmpty(),
+            TicketType.CARSHARING to gameViewModel.reachableStations(TicketType.CARSHARING).isNotEmpty(),
+            TicketType.BLACK      to true,
+            TicketType.DOUBLE     to true
+        )
+    }
     val isDoubleActive = gameState?.doubleMoveActive ?: false
     val mrXRevealed    = if (!isMrX) gameState?.mrXRevealedPositions ?: emptyMap() else emptyMap()
     val mrXHistory     = if (!isMrX) gameState?.mrXMoveHistory ?: emptyList() else emptyList()
@@ -429,6 +443,8 @@ private fun GameBoardRoute(
         isDoubleActive       = isDoubleActive,
         selectedTicket       = selectedTicket,
         currentPlayerColor   = currentPlayerColor,
+        ticketReachable      = ticketReachable,
+        allPlayersReady      = allPlayersReady,
         mrXMoveHistory       = mrXHistory,
         revealHistoryIndices = revealHistoryIndices,
         ticketCounts         = ticketCounts.toMutableMap().apply {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -104,6 +104,7 @@
     <string name="title_choose_start_position">Wähle deine Startposition</string>
     <string name="text_spin_and_confirm">Dreh das Rad und bestätige</string>
     <string name="button_confirm_station">Bestätige Station %1$d</string>
+    <string name="banner_waiting_for_players">Warte auf alle Spieler…</string>
     <string name="banner_double_move_hint">Doppel Fahrkarte aktiv – tippe auf eine Station um sie zu benutzen</string>
     <string name="banner_mrx_position_reveal">Mr. X wurde an Station %1$d gesichtet!</string>
     <string name="title_menu">Menü</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="text_spin_and_confirm">Spin the wheel and confirm</string>
     <string name="button_confirm_station">Confirm station %1$d</string>
 
+    <string name="banner_waiting_for_players">Waiting for all players to join…</string>
     <string name="banner_double_move_hint">Double Move active – tap a station to use</string>
     <string name="banner_mrx_position_reveal">Mr. X was spotted at station %1$d!</string>
     <string name="title_menu">Menu</string>


### PR DESCRIPTION
- Bug: Detective has no valid moves -> game stuck
  Tickets are now grayed out not only when count == 0 or it's not the player's turn,
  but also when the ticket type has no reachable destination from the player's current
  position (e.g. only WALKING connections available but no WALKING tickets left).
  Computed via BoardConnection.reachableFrom() for all three transport types. Applies
  to both detectives and MrX; BLACK and DOUBLE are always treated as reachable.

- Added "Waiting for all players to join..." banner on the game board that shows until
  allPlayersReady (from server) is true. isMyTurn is also suppressed client-side until
  then, so no moves can be sent even if the server check is somehow bypassed.

- In-game settings/menu button debounce raised to 1000ms to prevent accidental
  double-navigation to the settings screen. ->(no Server-settings lock)

- Mr. X reveal position badge (circle icon above ticket chip in move history) was
  being clipped in the first row because it used offset(y = -8.dp) outside the Box
  bounds. Fixed by adding padding(top = 8.dp) to all chips so the badge always lands
  within the composable's allocated space and rows stay aligned.

- Reveal banner ("Mr. X was spotted at...") can now be dismissed by tapping it.
  Auto-dismiss after 5s still works; tapping just sets showRevealBanner = false early.
  The LaunchedEffect key is currentRevealPosition so the banner reappears on the next
  reveal round regardless.

- Cheat button on the start position spinner screen commented out (code kept).